### PR TITLE
Add chart for mariadb-instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ helm repo add vshn https://charts.appcat.ch
 
 | Downloads & Changelog | Chart |
 | --- | --- |
+| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnmariadb-0.0.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnmariadb-0.0.1) | [vshnmariadb](charts/vshnmariadb/README.md) |
 
 ## Add / Update Charts
 

--- a/charts/vshnmariadb/Chart.yaml
+++ b/charts/vshnmariadb/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+appVersion: 2.7.3
+description: A Helm chart for MariaDB instances using the mariadb-operator
+name: vshnmariadb
+version: 0.0.1
+maintainers:
+  - name: Schedar Team
+    email: info@vshn.ch

--- a/charts/vshnmariadb/README.gotmpl.md
+++ b/charts/vshnmariadb/README.gotmpl.md
@@ -1,0 +1,39 @@
+<!---
+The README.md file is automatically generated with helm-docs!
+
+Edit the README.gotmpl.md template instead.
+-->
+
+## Introduction
+
+This helm chart is used to deploy mariadb instances using the [mariadb-operator](https://github.com/mariadb-operator/mariadb-operator).
+
+## Configuration
+
+The following table lists the configurable parameters chart. For default values and examples, consult `values.yaml`.
+
+### Generic parameters
+| Parameter               | Description                                               | Default
+|---                      | ---                                                       | ---
+| `image`                 | Image name to be used by the MariaDB instances. The supported format is <image>:<tag>.
+Only MariaDB official images are supported. | 
+| `replicas`              | Number of replicas to deploy                              | 3
+| `myCnf`                 | Custom MariaDB configuration                              | ""
+| `storage.size`          | PVC size of the instance                                  | 1Gi
+| `resources`             | Resources describes the compute resource requirements.    |
+| `rootPasswordSecretKeyRef` | Reference to the secret containing the root password   |
+
+### Galera
+
+| Parameter                             | Description                     | Default
+|---                                    | ---                             | ---
+| `galera.enabled`                      | If galera should be enabled     | true
+| `galera.config.resuseStorageVolume`   | ReuseStorageVolume indicates that storage volume used by MariaDB should be reused to store the Galera configuration files.    | true
+| `galera.providerOptions`              | ProviderOptions is map of Galera configuration parameters. [More info]( https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_provider_options). | `{'gcs.fc_single_primary': yes', 'cert.log_conflicts': 'yes'}`
+
+### Metrics
+
+| Parameter                             | Description                            | Default
+| ---                                   | ---                                    | ---
+| `metrics.enabled`                     | Enabled is a flag to enable Metrics    | true
+| `exporter.image`                      | Image name to be used as metrics exporter. The supported format is <image>:<tag>. |

--- a/charts/vshnmariadb/README.md
+++ b/charts/vshnmariadb/README.md
@@ -1,0 +1,57 @@
+# vshnmariadb
+
+![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![AppVersion: 2.7.3](https://img.shields.io/badge/AppVersion-2.7.3-informational?style=flat-square)
+
+A Helm chart for MariaDB instances using the mariadb-operator
+
+## Installation
+
+```bash
+helm repo add appcat https://charts.appcat.ch
+helm install vshnmariadb vshn/vshnmariadb
+```
+<!---
+The README.md file is automatically generated with helm-docs!
+
+Edit the README.gotmpl.md template instead.
+-->
+
+## Introduction
+
+This helm chart is used to deploy mariadb instances using the [mariadb-operator](https://github.com/mariadb-operator/mariadb-operator).
+
+## Configuration
+
+The following table lists the configurable parameters chart. For default values and examples, consult `values.yaml`.
+
+### Generic parameters
+| Parameter               | Description                                               | Default
+|---                      | ---                                                       | ---
+| `image`                 | Image name to be used by the MariaDB instances. The supported format is <image>:<tag>.
+Only MariaDB official images are supported. |
+| `replicas`              | Number of replicas to deploy                              | 3
+| `myCnf`                 | Custom MariaDB configuration                              | ""
+| `storage.size`          | PVC size of the instance                                  | 1Gi
+| `resources`             | Resources describes the compute resource requirements.    |
+| `rootPasswordSecretKeyRef` | Reference to the secret containing the root password   |
+
+### Galera
+
+| Parameter                             | Description                     | Default
+|---                                    | ---                             | ---
+| `galera.enabled`                      | If galera should be enabled     | true
+| `galera.config.resuseStorageVolume`   | ReuseStorageVolume indicates that storage volume used by MariaDB should be reused to store the Galera configuration files.    | true
+| `galera.providerOptions`              | ProviderOptions is map of Galera configuration parameters. [More info]( https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_provider_options). | `{'gcs.fc_single_primary': yes', 'cert.log_conflicts': 'yes'}`
+
+### Metrics
+
+| Parameter                             | Description                            | Default
+| ---                                   | ---                                    | ---
+| `metrics.enabled`                     | Enabled is a flag to enable Metrics    | true
+| `exporter.image`                      | Image name to be used as metrics exporter. The supported format is <image>:<tag>. |
+
+<!---
+Common/Useful Link references from values.yaml
+-->
+[resource-units]: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+[prometheus-operator]: https://github.com/coreos/prometheus-operator

--- a/charts/vshnmariadb/templates/_helpers.tpl
+++ b/charts/vshnmariadb/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mariadb.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mariadb.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mariadb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/vshnmariadb/templates/mariadb.yaml
+++ b/charts/vshnmariadb/templates/mariadb.yaml
@@ -1,0 +1,33 @@
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: MariaDB
+metadata:
+  name: {{ include "mariadb.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "mariadb.name" . }}
+    helm.sh/chart: {{ include "mariadb.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  {{- with .Values.rootPasswordSecretKeyRef }}
+  rootPasswordSecretKeyRef: {{ . | toYaml | nindent 4 }}
+  {{- end }}
+  image: {{ .Values.image }}
+  replicas: {{ .Values.replicas }}
+  myCnf: {{ .Values.myCnf }}
+  {{- with .Values.resources }}
+  resources: {{ . | toYaml | nindent 4 }}
+  {{- end }}
+  metrics:
+    enabled: {{ .Values.metrics.enabled }}
+    exporter:
+      image: {{ .Values.metrics.exporter.image }}
+  galera:
+    enabled: {{ .Values.galera.enabled }}
+    config:
+      reuseStorageVolume: {{ .Values.galera.config.reuseStorageVolume }}
+    {{- with .Values.galera.providerOptions }}
+    providerOptions: {{ . | toYaml | nindent 6 }}
+    {{- end }}
+  storage:
+    size: {{ .Values.storage.size }}
+

--- a/charts/vshnmariadb/values.yaml
+++ b/charts/vshnmariadb/values.yaml
@@ -1,0 +1,21 @@
+replicas: 3
+myCfn: nil
+rootPasswordSecretKeyRef: {}
+image: nil
+
+storage:
+  size: 1Gi
+resources: {}
+
+galera:
+  enabled: true
+  config:
+    reuseStorageVolume: true
+  providerOptions:
+    'gcs.fc_single_primary': 'yes'
+    'cert.log_conflicts': 'yes'
+
+metrics:
+  enabled: true
+  exporter:
+    image: nil


### PR DESCRIPTION
<!--
Thank you for contributing to vshn/appcat-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

* This PR adds support for creating mariadb instances for the mariadb-operator

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
