### PR TITLE
Add backup option for mariadb instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ helm repo add appcat https://charts.appcat.ch
 
 | Downloads & Changelog | Chart |
 | --- | --- |
-| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnmariadb-0.0.3/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnmariadb-0.0.3) | [vshnmariadb](charts/vshnmariadb/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnmariadb-0.0.4/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnmariadb-0.0.4) | [vshnmariadb](charts/vshnmariadb/README.md) |
 
 ## Add / Update Charts
 

--- a/charts/vshnmariadb/Chart.yaml
+++ b/charts/vshnmariadb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.0.3
+appVersion: 0.0.4
 description: A Helm chart for MariaDB instances using the mariadb-operator
 name: vshnmariadb
-version: 0.0.3
+version: 0.0.4
 maintainers:
   - name: Schedar Team
     email: info@vshn.ch

--- a/charts/vshnmariadb/README.gotmpl.md
+++ b/charts/vshnmariadb/README.gotmpl.md
@@ -22,6 +22,7 @@ Only MariaDB official images are supported. |
 | `storage.size`          | PVC size of the instance                                  | 1Gi
 | `resources`             | Resources describes the compute resource requirements.    |
 | `rootPasswordSecretKeyRef` | Reference to the secret containing the root password   |
+| `affinity`              | Definites the affinity for the pods                       |
 
 ### Galera
 

--- a/charts/vshnmariadb/README.gotmpl.md
+++ b/charts/vshnmariadb/README.gotmpl.md
@@ -37,3 +37,13 @@ Only MariaDB official images are supported. |
 | ---                                   | ---                                    | ---
 | `metrics.enabled`                     | Enabled is a flag to enable Metrics    | true
 | `exporter.image`                      | Image name to be used as metrics exporter. The supported format is <image>:<tag>. |
+
+### Backup
+
+| Parameter                             | Description                               | Default
+| ---                                   | ---                                       | ---
+| `backup.enabled`                      | Enabled is a flag to enable backups       | false
+| `backup.s3.bucket`                    | Name of the s3 bucket for the backups     |
+| `backup.s3.endpoint`                  | Name of the s3 endpoint for the backups   |
+| `backup.s3.accessKey`                 | Access key for the s3 bucket              |
+| `backup.s3.secretKey`                 | Secret key for the s3 bucket              |

--- a/charts/vshnmariadb/README.md
+++ b/charts/vshnmariadb/README.md
@@ -1,6 +1,6 @@
 # vshnmariadb
 
-![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![AppVersion: 0.0.3](https://img.shields.io/badge/AppVersion-0.0.3-informational?style=flat-square)
+![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![AppVersion: 0.0.4](https://img.shields.io/badge/AppVersion-0.0.4-informational?style=flat-square)
 
 A Helm chart for MariaDB instances using the mariadb-operator
 
@@ -49,6 +49,16 @@ Only MariaDB official images are supported. |
 | ---                                   | ---                                    | ---
 | `metrics.enabled`                     | Enabled is a flag to enable Metrics    | true
 | `exporter.image`                      | Image name to be used as metrics exporter. The supported format is <image>:<tag>. |
+
+### Backup
+
+| Parameter                             | Description                               | Default
+| ---                                   | ---                                       | ---
+| `backup.enabled`                      | Enabled is a flag to enable backups       | false
+| `backup.s3.bucket`                    | Name of the s3 bucket for the backups     |
+| `backup.s3.endpoint`                  | Name of the s3 endpoint for the backups   |
+| `backup.s3.accessKey`                 | Access key for the s3 bucket              |
+| `backup.s3.secretKey`                 | Secret key for the s3 bucket              |
 
 <!---
 Common/Useful Link references from values.yaml

--- a/charts/vshnmariadb/README.md
+++ b/charts/vshnmariadb/README.md
@@ -34,6 +34,7 @@ Only MariaDB official images are supported. |
 | `storage.size`          | PVC size of the instance                                  | 1Gi
 | `resources`             | Resources describes the compute resource requirements.    |
 | `rootPasswordSecretKeyRef` | Reference to the secret containing the root password   |
+| `affinity`              | Definites the affinity for the pods                       |
 
 ### Galera
 

--- a/charts/vshnmariadb/templates/backup.yaml
+++ b/charts/vshnmariadb/templates/backup.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.backup.enabled -}}
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: PhysicalBackup
+metadata:
+  name: {{ include "mariadb.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "mariadb.name" . }}
+    helm.sh/chart: {{ include "mariadb.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  mariaDbRef:
+    name: {{ include "mariadb.fullname" . }}
+  storage:
+    schedule:
+      {{/* Generate uniform random minute (0–59) */}}
+      {{- $minute := (randNumeric 2 | atoi) -}}
+      {{- if gt $minute 59 -}}{{- $minute = (mod $minute 60) -}}{{- end -}}
+
+      {{/* Generate uniform random hour (0–23) */}}
+      {{- $hour := (randNumeric 2 | atoi) -}}
+      {{- if gt $hour 95 }}{{- $hour = (mod $hour 24) }}{{- end -}}
+      {{- $hour = (mod $hour 24) -}}
+      cron: {{ printf "%d %d * * *" $minute $hour }}
+    s3:
+      bucket: {{ .Values.backup.s3.bucket }}
+      endpoint: {{ .Values.backup.s3.endpoint }}
+      accessKeyIdSecretKeyRef:
+        name: backup
+        key: access-key
+      secretAccessKeySecretKeyRef:
+        name: backup
+        key: secret-key
+      tls:
+        enabled: true
+  stagingStorage:
+    persistentVolumeClaim:
+      resources:
+        requests:
+          storage: {{ .Values.storage.size }}
+      accessModes:
+        - ReadWriteOnce 
+{{- end -}}

--- a/charts/vshnmariadb/templates/backup.yaml
+++ b/charts/vshnmariadb/templates/backup.yaml
@@ -17,10 +17,13 @@ spec:
       {{- $minute := (randNumeric 2 | atoi) -}}
       {{- if gt $minute 59 -}}{{- $minute = (mod $minute 60) -}}{{- end -}}
 
-      {{/* Generate uniform random hour (0–23) */}}
-      {{- $hour := (randNumeric 2 | atoi) -}}
-      {{- if gt $hour 95 }}{{- $hour = (mod $hour 24) }}{{- end -}}
-      {{- $hour = (mod $hour 24) -}}
+      {{/* Random index 0–7 */}}
+      {{- $r := (mod (atoi (randNumeric 2)) 8) -}}
+
+      {{/* Allowed night hours */}}
+      {{- $nightHours := list 22 23 0 1 2 3 4 5 -}}
+
+      {{- $hour := index $nightHours $r -}}
       cron: {{ printf "%d %d * * *" $minute $hour }}
     s3:
       bucket: {{ .Values.backup.s3.bucket }}

--- a/charts/vshnmariadb/templates/backup_secret.yaml
+++ b/charts/vshnmariadb/templates/backup_secret.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.backup.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backup
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/name: {{ include "mariadb.name" . }}
+    helm.sh/chart: {{ include "mariadb.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  access-key: {{ .Values.backup.s3.accessKey | b64enc | quote }}
+  secret-key: {{ .Values.backup.s3.secretKey | b64enc | quote }}
+{{- end -}}

--- a/charts/vshnmariadb/templates/mariadb.yaml
+++ b/charts/vshnmariadb/templates/mariadb.yaml
@@ -7,7 +7,6 @@ metadata:
     helm.sh/chart: {{ include "mariadb.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-
 spec:
   {{ if .Values.rootPasswordSecretKeyRef}}
   rootPasswordSecretKeyRef: {{ .Values.rootPasswordSecretKeyRef | toYaml | nindent 4 }}

--- a/charts/vshnmariadb/templates/mariadb.yaml
+++ b/charts/vshnmariadb/templates/mariadb.yaml
@@ -34,4 +34,7 @@ spec:
     {{- end }}
   storage:
     size: {{ .Values.storage.size }}
+  {{- with .Values.affinity }}
+  affinity: {{ . | toYaml | nindent 4 }}
+  {{- end }}
 

--- a/charts/vshnmariadb/values.yaml
+++ b/charts/vshnmariadb/values.yaml
@@ -20,3 +20,6 @@ metrics:
   enabled: true
   exporter:
     image: nil
+
+backup:
+  enabled: false


### PR DESCRIPTION
<!--
Thank you for contributing to vshn/appcat-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

* This PR adds the option to enable physical backups for mariadb instances using the mariadb-operator
* When enabled it will deploy a secret for the s3 backend as well as a `PhysicalBackup` object for the backup

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
