### PR TITLE
Add maxRetention field for mariadb backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ helm repo add appcat https://charts.appcat.ch
 
 | Downloads & Changelog | Chart |
 | --- | --- |
-| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnmariadb-0.0.5/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnmariadb-0.0.5) | [vshnmariadb](charts/vshnmariadb/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnmariadb-0.0.6/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnmariadb-0.0.6) | [vshnmariadb](charts/vshnmariadb/README.md) |
 
 ## Add / Update Charts
 

--- a/charts/vshnmariadb/Chart.yaml
+++ b/charts/vshnmariadb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.0.5
+appVersion: 0.0.6
 description: A Helm chart for MariaDB instances using the mariadb-operator
 name: vshnmariadb
-version: 0.0.5
+version: 0.0.6
 maintainers:
   - name: Schedar Team
     email: info@vshn.ch

--- a/charts/vshnmariadb/README.gotmpl.md
+++ b/charts/vshnmariadb/README.gotmpl.md
@@ -44,6 +44,7 @@ Only MariaDB official images are supported. |
 | Parameter                             | Description                               | Default
 | ---                                   | ---                                       | ---
 | `backup.enabled`                      | Enabled is a flag to enable backups       | false
+| `backup.maxRention`                   | Max retention for the backups in hours    | 720h # 30 days
 | `backup.s3.bucket`                    | Name of the s3 bucket for the backups     |
 | `backup.s3.endpoint`                  | Name of the s3 endpoint for the backups   |
 | `backup.s3.accessKey`                 | Access key for the s3 bucket              |

--- a/charts/vshnmariadb/README.md
+++ b/charts/vshnmariadb/README.md
@@ -1,6 +1,6 @@
 # vshnmariadb
 
-![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square) ![AppVersion: 0.0.5](https://img.shields.io/badge/AppVersion-0.0.5-informational?style=flat-square)
+![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square) ![AppVersion: 0.0.6](https://img.shields.io/badge/AppVersion-0.0.6-informational?style=flat-square)
 
 A Helm chart for MariaDB instances using the mariadb-operator
 
@@ -56,6 +56,7 @@ Only MariaDB official images are supported. |
 | Parameter                             | Description                               | Default
 | ---                                   | ---                                       | ---
 | `backup.enabled`                      | Enabled is a flag to enable backups       | false
+| `backup.maxRention`                   | Max retention for the backups in hours    | 720h # 30 days
 | `backup.s3.bucket`                    | Name of the s3 bucket for the backups     |
 | `backup.s3.endpoint`                  | Name of the s3 endpoint for the backups   |
 | `backup.s3.accessKey`                 | Access key for the s3 bucket              |

--- a/charts/vshnmariadb/templates/backup.yaml
+++ b/charts/vshnmariadb/templates/backup.yaml
@@ -11,6 +11,7 @@ metadata:
 spec:
   mariaDbRef:
     name: {{ include "mariadb.fullname" . }}
+  maxRetention: {{ .Values.backup.maxRetention }}
   schedule:
     {{/* Generate uniform random minute (0–59) */}}
     {{- $minute := (randNumeric 2 | atoi) -}}

--- a/charts/vshnmariadb/values.yaml
+++ b/charts/vshnmariadb/values.yaml
@@ -23,3 +23,4 @@ metrics:
 
 backup:
   enabled: false
+  maxRetention: 720h # 30 days


### PR DESCRIPTION
<!--
Thank you for contributing to vshn/appcat-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

* This PR adds a new `maxRetention` field for the mariadb backups

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
