### PR TITLE
feat: allow to run release.yml on workflow dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   gh-pages:
@@ -25,5 +26,6 @@ jobs:
         with:
           charts_dir: charts
           charts_repo_url: https://charts.appcat.ch
+          skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
If something went wrong you now have a second chance. And you can release from a release branch to apply bugfixes to old releases.

You need to cherry pick this commit
onto the release branch that this is possible on old branches. This ports the fix of:
- https://github.com/appuio/charts/pull/535
To this repo.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [ ] ~~Chart Version bumped~~ (no changes on charts)
- [ ] ~~I have run `make docs`~~ (no changes on charts)
