### PR TITLE
Add probes support and adjust default startupProbe failureThreshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ helm repo add appcat https://charts.appcat.ch
 
 | Downloads & Changelog | Chart |
 | --- | --- |
-| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnmariadb-0.0.11/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnmariadb-0.0.11) | [vshnmariadb](charts/vshnmariadb/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnmariadb-0.0.12/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnmariadb-0.0.12) | [vshnmariadb](charts/vshnmariadb/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnpostgresql-0.5.0/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnpostgresql-0.5.0) | [vshnpostgresql](charts/vshnpostgresql/README.md) |
 
 ## Add / Update Charts

--- a/charts/vshnmariadb/Chart.yaml
+++ b/charts/vshnmariadb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.0.11
+appVersion: 0.0.12
 description: A Helm chart for MariaDB instances using the mariadb-operator
 name: vshnmariadb
-version: 0.0.11
+version: 0.0.12
 maintainers:
   - name: Schedar Team
     email: info@vshn.ch

--- a/charts/vshnmariadb/README.gotmpl.md
+++ b/charts/vshnmariadb/README.gotmpl.md
@@ -23,6 +23,9 @@ Only MariaDB official images are supported. |
 | `resources`             | Resources describes the compute resource requirements.    |
 | `rootPasswordSecretKeyRef` | Reference to the secret containing the root password   |
 | `affinity`              | Definites the affinity for the pods                       |
+| `startupProbe`          | Startup probe configuration for MariaDB containers        | `{failureThreshold: 30}`
+| `livenessProbe`         | Liveness probe configuration for MariaDB containers       |
+| `readinessProbe`        | Readiness probe configuration for MariaDB containers      |
 
 ### Galera
 

--- a/charts/vshnmariadb/README.md
+++ b/charts/vshnmariadb/README.md
@@ -1,6 +1,6 @@
 # vshnmariadb
 
-![Version: 0.0.11](https://img.shields.io/badge/Version-0.0.11-informational?style=flat-square) ![AppVersion: 0.0.11](https://img.shields.io/badge/AppVersion-0.0.11-informational?style=flat-square)
+![Version: 0.0.12](https://img.shields.io/badge/Version-0.0.12-informational?style=flat-square) ![AppVersion: 0.0.12](https://img.shields.io/badge/AppVersion-0.0.12-informational?style=flat-square)
 
 A Helm chart for MariaDB instances using the mariadb-operator
 
@@ -35,6 +35,9 @@ Only MariaDB official images are supported. |
 | `resources`             | Resources describes the compute resource requirements.    |
 | `rootPasswordSecretKeyRef` | Reference to the secret containing the root password   |
 | `affinity`              | Definites the affinity for the pods                       |
+| `startupProbe`          | Startup probe configuration for MariaDB containers        | `{failureThreshold: 30}`
+| `livenessProbe`         | Liveness probe configuration for MariaDB containers       |
+| `readinessProbe`        | Readiness probe configuration for MariaDB containers      |
 
 ### Galera
 

--- a/charts/vshnmariadb/templates/mariadb.yaml
+++ b/charts/vshnmariadb/templates/mariadb.yaml
@@ -21,6 +21,15 @@ spec:
   {{- with .Values.resources }}
   resources: {{ . | toYaml | nindent 4 }}
   {{- end }}
+  {{- with .Values.startupProbe }}
+  startupProbe: {{ . | toYaml | nindent 4 }}
+  {{- end }}
+  {{- with .Values.livenessProbe }}
+  livenessProbe: {{ . | toYaml | nindent 4 }}
+  {{- end }}
+  {{- with .Values.readinessProbe }}
+  readinessProbe: {{ . | toYaml | nindent 4 }}
+  {{- end }}
   metrics:
     enabled: {{ .Values.metrics.enabled }}
     exporter:

--- a/charts/vshnmariadb/values.yaml
+++ b/charts/vshnmariadb/values.yaml
@@ -13,8 +13,11 @@ galera:
   config:
     reuseStorageVolume: true
   providerOptions:
-    'gcs.fc_single_primary': 'yes'
-    'cert.log_conflicts': 'yes'
+    "gcs.fc_single_primary": "yes"
+    "cert.log_conflicts": "yes"
+
+startupProbe:
+  failureThreshold: 30
 
 metrics:
   enabled: true


### PR DESCRIPTION

<!--
Thank you for contributing to vshn/appcat-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

This commit adds support for various probes. It also increases the default failureThreshold for the startupProbe from 3 to 30.
With the default `periodSeconds` of 10, this increases the effective time for a startup from 30s to 300s.

The default is way too low for any decently sized galera cluster and will result in the pod being killed during an SST if the db is too big

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
