### PR TITLE
Add isOpenshift parameter to rcloneproxy chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ helm repo add appcat https://charts.appcat.ch
 
 | Downloads & Changelog | Chart |
 | --- | --- |
-| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/rcloneproxy-0.0.1/total)](https://github.com/vshn/appcat-charts/releases/tag/rcloneproxy-0.0.1) | [rcloneproxy](charts/rcloneproxy/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/rcloneproxy-0.0.2/total)](https://github.com/vshn/appcat-charts/releases/tag/rcloneproxy-0.0.2) | [rcloneproxy](charts/rcloneproxy/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnmariadb-0.0.12/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnmariadb-0.0.12) | [vshnmariadb](charts/vshnmariadb/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnpostgresql-0.6.0/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnpostgresql-0.6.0) | [vshnpostgresql](charts/vshnpostgresql/README.md) |
 

--- a/charts/rcloneproxy/Chart.yaml
+++ b/charts/rcloneproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rcloneproxy
 description: A Helm chart for deploying rclone as an intermediate s3 proxy
 type: application
-version: 0.0.1
+version: 0.0.2
 maintainers:
   - name: Schedar Team
     email: info@vshn.ch

--- a/charts/rcloneproxy/README.md
+++ b/charts/rcloneproxy/README.md
@@ -1,6 +1,6 @@
 # rcloneproxy
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying rclone as an intermediate s3 proxy
 
@@ -18,7 +18,7 @@ Common/Useful Link references from values.yaml
 [prometheus-operator]: https://github.com/coreos/prometheus-operator
 # rcloneproxy
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying rclone as an intermediate s3 proxy
 
@@ -51,6 +51,7 @@ A Helm chart for deploying rclone as an intermediate s3 proxy
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"ghcr.io/rclone/rclone"` | Image repository for rclone |
 | image.tag | string | `"1.73.0"` | Configure the image tag |
+| isOpenshift | bool | `false` | Set to true when deploying on OpenShift |
 | podSecurityContext | object | `{"enabled":true,"fsGroup":65532,"fsGroupChangePolicy":"OnRootMismatch","seLinuxOptions":{}}` | Pod security context configuration |
 | podSecurityContext.enabled | bool | `true` | Enable pod security context |
 | podSecurityContext.fsGroup | int | `65532` | FSGroup for volume ownership |

--- a/charts/rcloneproxy/templates/deployment.yaml
+++ b/charts/rcloneproxy/templates/deployment.yaml
@@ -16,6 +16,11 @@ spec:
     spec:
       {{- if .Values.podSecurityContext.enabled }}
       securityContext:
+        {{- if .Values.isOpenshift }}
+        fsGroupChangePolicy: OnRootMismatch
+        seLinuxOptions:
+          type: spc_t
+        {{- else }}
         {{- if .Values.podSecurityContext.fsGroup }}
         fsGroup: {{ .Values.podSecurityContext.fsGroup }}
         {{- end }}
@@ -26,6 +31,7 @@ spec:
         seLinuxOptions:
           {{- toYaml .Values.podSecurityContext.seLinuxOptions | nindent 10 }}
         {{- end }}
+        {{- end }}
       {{- end }}
       initContainers:
         - name: generate-config
@@ -33,6 +39,15 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.containerSecurityContext.enabled }}
           securityContext:
+            {{- if .Values.isOpenshift }}
+            {{- /* OpenShift: Let SCC assign runAsUser */}}
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+            {{- else }}
             {{- if .Values.containerSecurityContext.runAsUser }}
             runAsUser: {{ .Values.containerSecurityContext.runAsUser }}
             {{- end }}
@@ -48,6 +63,7 @@ spec:
             {{- if .Values.containerSecurityContext.capabilities }}
             capabilities:
               {{- toYaml .Values.containerSecurityContext.capabilities | nindent 14 }}
+            {{- end }}
             {{- end }}
           {{- end }}
           command:
@@ -128,6 +144,14 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.containerSecurityContext.enabled }}
           securityContext:
+            {{- if .Values.isOpenshift }}
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+            {{- else }}
             {{- if .Values.containerSecurityContext.runAsUser }}
             runAsUser: {{ .Values.containerSecurityContext.runAsUser }}
             {{- end }}
@@ -143,6 +167,7 @@ spec:
             {{- if .Values.containerSecurityContext.capabilities }}
             capabilities:
               {{- toYaml .Values.containerSecurityContext.capabilities | nindent 14 }}
+            {{- end }}
             {{- end }}
           {{- end }}
           command:

--- a/charts/rcloneproxy/values.yaml
+++ b/charts/rcloneproxy/values.yaml
@@ -44,6 +44,9 @@ resources:
     memory: "512Mi"
     cpu: "25m"
 
+# -- Set to true when deploying on OpenShift
+isOpenshift: false
+
 # -- Pod security context configuration
 podSecurityContext:
   # -- Enable pod security context


### PR DESCRIPTION
#### What this PR does / why we need it

This adds the isOpenshift parameter to the rcloneproxy helmchart which configures the security context for openshift.

#### Checklist
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [ ] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [ ] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
