### PR TITLE
Fix missing region for ObjectStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ helm repo add appcat https://charts.appcat.ch
 | --- | --- |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/rcloneproxy-0.0.2/total)](https://github.com/vshn/appcat-charts/releases/tag/rcloneproxy-0.0.2) | [rcloneproxy](charts/rcloneproxy/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnmariadb-0.0.12/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnmariadb-0.0.12) | [vshnmariadb](charts/vshnmariadb/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnpostgresql-0.7.0/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnpostgresql-0.7.0) | [vshnpostgresql](charts/vshnpostgresql/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnpostgresql-0.7.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnpostgresql-0.7.1) | [vshnpostgresql](charts/vshnpostgresql/README.md) |
 
 ## Add / Update Charts
 

--- a/charts/vshnpostgresql/Chart.yaml
+++ b/charts/vshnpostgresql/Chart.yaml
@@ -20,8 +20,8 @@ apiVersion: v2
 name: vshnpostgresql
 description: A Helm chart for PostgreSQL clusters using the CloudNativePG operator
 type: application
-version: 0.7.0
-appVersion: 0.7.0
+version: 0.7.1
+appVersion: 0.7.1
 maintainers:
   - name: Schedar Team
     email: info@vshn.ch

--- a/charts/vshnpostgresql/README.md
+++ b/charts/vshnpostgresql/README.md
@@ -1,6 +1,6 @@
 # vshnpostgresql
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
+![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.1](https://img.shields.io/badge/AppVersion-0.7.1-informational?style=flat-square)
 
 A Helm chart for PostgreSQL clusters using the CloudNativePG operator
 

--- a/charts/vshnpostgresql/templates/_barman_object_store.tpl
+++ b/charts/vshnpostgresql/templates/_barman_object_store.tpl
@@ -32,6 +32,9 @@
     secretAccessKey:
       name: {{ $secretName }}
       key: ACCESS_SECRET_KEY
+    region:
+      name: {{ $secretName }}
+      key: region
   {{- end }}
 {{- else if eq .scope.provider "azure" }}
   {{- if empty .scope.destinationPath }}

--- a/charts/vshnpostgresql/templates/backup-s3-creds.yaml
+++ b/charts/vshnpostgresql/templates/backup-s3-creds.yaml
@@ -7,4 +7,5 @@ metadata:
 data:
   ACCESS_KEY_ID: {{ required ".Values.backups.s3.accessKey is required, but not specified." .Values.backups.s3.accessKey | b64enc | quote }}
   ACCESS_SECRET_KEY: {{ required ".Values.backups.s3.secretKey is required, but not specified." .Values.backups.s3.secretKey | b64enc | quote }}
+  region: {{ required ".Values.backups.s3.region is required, but not specified." .Values.backups.s3.region | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
While most S3 implementations will happily accept the default "us-east-1", some will not work and need an explicit region.

<!--
Thank you for contributing to vshn/appcat-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

* Short summary

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [ ] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
