### PR TITLE
Add chart for garage bucket and user

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ helm repo add appcat https://charts.appcat.ch
 | Downloads & Changelog | Chart |
 | --- | --- |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/rcloneproxy-0.0.2/total)](https://github.com/vshn/appcat-charts/releases/tag/rcloneproxy-0.0.2) | [rcloneproxy](charts/rcloneproxy/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragebucket-0.0.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragebucket-0.0.1) | [vshngaragebucket](charts/vshngaragebucket/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragecluster-0.0.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragecluster-0.0.1) | [vshngaragecluster](charts/vshngaragecluster/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnmariadb-0.0.12/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnmariadb-0.0.12) | [vshnmariadb](charts/vshnmariadb/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnpostgresql-0.7.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnpostgresql-0.7.1) | [vshnpostgresql](charts/vshnpostgresql/README.md) |

--- a/charts/vshngaragebucket/Chart.yaml
+++ b/charts/vshngaragebucket/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: vshngaragebucket
+description: A Helm chart for deploying a garage cluster via garage operator
+type: application
+version: 0.0.1
+maintainers:
+  - name: Schedar Team
+    email: info@vshn.ch

--- a/charts/vshngaragebucket/README.md
+++ b/charts/vshngaragebucket/README.md
@@ -1,0 +1,38 @@
+# vshngaragebucket
+
+![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+A Helm chart for deploying a garage cluster via garage operator
+
+## Installation
+
+```bash
+helm repo add appcat https://charts.appcat.ch
+helm install vshngaragebucket vshn/vshngaragebucket
+```
+
+<!---
+Common/Useful Link references from values.yaml
+-->
+[resource-units]: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+[prometheus-operator]: https://github.com/coreos/prometheus-operator
+# vshngaragebucket
+
+![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+A Helm chart for deploying a garage cluster via garage operator
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Schedar Team | <info@vshn.ch> |  |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| bucketName | string | `""` | Name of the bucket, if empty, will be randomly generated |
+| claimNamespace | string | `""` | ClaimNamespace is needed to lookup the necessary information about the instanceNamespace |
+| clusterRef | string | `""` | ClusterRef is the name of the cluster that should get the bucket |
+

--- a/charts/vshngaragebucket/templates/_helpers.tpl
+++ b/charts/vshngaragebucket/templates/_helpers.tpl
@@ -1,0 +1,9 @@
+{{- required ".Values.bucketName is required." .Values.bucketName -}}
+{{- required ".Values.clusterRef is required." .Values.clusterRef -}}
+{{- required ".Values.claimNamespace is required." .Values.claimNamespace -}}
+
+# We need to get the instance namespace for the given clusterRef, so that we know where it is.
+{{- define "instanceNamespace" -}}
+{{- $existingClaim := lookup "vshn.appcat.vshn.io/v1" "VSHNGarage" .Values.claimNamespace .Values.clusterRef -}}
+  {{- $existingClaim.status.instanceNamespace -}}
+{{- end -}}

--- a/charts/vshngaragebucket/templates/bucket.yaml
+++ b/charts/vshngaragebucket/templates/bucket.yaml
@@ -1,0 +1,8 @@
+apiVersion: garage.rajsingh.info/v1alpha1
+kind: GarageBucket
+metadata:
+  name: {{ .Values.bucketName }}
+spec:
+  clusterRef:
+    name: {{.Values.clusterRef}}
+    namespace: {{ include "instanceNamespace" . }}

--- a/charts/vshngaragebucket/templates/credentials.yaml
+++ b/charts/vshngaragebucket/templates/credentials.yaml
@@ -1,0 +1,12 @@
+apiVersion: garage.rajsingh.info/v1alpha1
+kind: GarageKey
+metadata:
+  name: {{ .Values.bucketName }}
+spec:
+  clusterRef:
+    name: {{.Values.clusterRef}}
+    namespace: {{ include "instanceNamespace" . }}
+  bucketPermissions:
+    - bucketRef: {{ .Values.bucketName }}
+      read: true
+      write: true

--- a/charts/vshngaragebucket/values.yaml
+++ b/charts/vshngaragebucket/values.yaml
@@ -1,0 +1,8 @@
+# -- Name of the bucket, if empty, will be randomly generated
+bucketName: ""
+
+# -- ClusterRef is the name of the cluster that should get the bucket
+clusterRef: ""
+
+# -- ClaimNamespace is needed to lookup the necessary information about the instanceNamespace
+claimNamespace: ""


### PR DESCRIPTION
<!--
Thank you for contributing to vshn/appcat-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

* Add bucket provisioning for Garage clusters
* This chart is deployed via composition function here: https://github.com/vshn/appcat/pull/603

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
