### PR TITLE
Don't override imageCatalog if it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ helm repo add appcat https://charts.appcat.ch
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragebucket-0.0.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragebucket-0.0.1) | [vshngaragebucket](charts/vshngaragebucket/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragecluster-0.0.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragecluster-0.0.1) | [vshngaragecluster](charts/vshngaragecluster/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnmariadb-0.0.12/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnmariadb-0.0.12) | [vshnmariadb](charts/vshnmariadb/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnpostgresql-0.7.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnpostgresql-0.7.1) | [vshnpostgresql](charts/vshnpostgresql/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnpostgresql-0.7.2/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnpostgresql-0.7.2) | [vshnpostgresql](charts/vshnpostgresql/README.md) |
 
 ## Add / Update Charts
 

--- a/charts/vshnpostgresql/Chart.yaml
+++ b/charts/vshnpostgresql/Chart.yaml
@@ -20,8 +20,8 @@ apiVersion: v2
 name: vshnpostgresql
 description: A Helm chart for PostgreSQL clusters using the CloudNativePG operator
 type: application
-version: 0.7.1
-appVersion: 0.7.1
+version: 0.7.2
+appVersion: 0.7.2
 maintainers:
   - name: Schedar Team
     email: info@vshn.ch

--- a/charts/vshnpostgresql/README.md
+++ b/charts/vshnpostgresql/README.md
@@ -1,6 +1,6 @@
 # vshnpostgresql
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.1](https://img.shields.io/badge/AppVersion-0.7.1-informational?style=flat-square)
+![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.2](https://img.shields.io/badge/AppVersion-0.7.2-informational?style=flat-square)
 
 A Helm chart for PostgreSQL clusters using the CloudNativePG operator
 

--- a/charts/vshnpostgresql/templates/image-catalog.yaml
+++ b/charts/vshnpostgresql/templates/image-catalog.yaml
@@ -1,4 +1,13 @@
 {{ if and .Values.imageCatalog.create (not (empty .Values.imageCatalog.images )) }}
+{{- $name := include "cluster.fullname" . -}}
+{{- $namespace := include "cluster.namespace" . -}}
+{{- $existingCatalog := lookup "postgresql.cnpg.io/v1" "ImageCatalog" $namespace $name -}}
+{{- $images := "" -}}
+{{- if $existingCatalog -}}
+  {{- $images = $existingCatalog.spec.images -}}
+{{- else -}}
+  {{- $images = .Values.imageCatalog.images -}}
+{{- end -}}
 apiVersion: postgresql.cnpg.io/v1
 kind: ImageCatalog
 metadata:
@@ -6,7 +15,7 @@ metadata:
   namespace: {{ include "cluster.namespace" . }}
 spec:
   images:
-    {{- range $image := .Values.imageCatalog.images }}
+    {{- range $image := $images }}
     - image: {{ $image.image }}
       major: {{ $image.major }}
     {{- end }}


### PR DESCRIPTION


<!--
Thank you for contributing to vshn/appcat-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:
This fixes an issue where the image catalog gets overwritten when the chart is applied again.

This can lead to several issues:
- Can trigger a downgrade if the images in the values are older than what's currently in the catalog
- Breaks the major upgrade logic, because the images might not match anymore between the varius major versions.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
