### PR TITLE
Add post-upgrade backup job for vshnpostgresql

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ helm repo add appcat https://charts.appcat.ch
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragebucket-0.0.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragebucket-0.0.1) | [vshngaragebucket](charts/vshngaragebucket/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragecluster-0.0.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragecluster-0.0.1) | [vshngaragecluster](charts/vshngaragecluster/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnmariadb-0.0.12/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnmariadb-0.0.12) | [vshnmariadb](charts/vshnmariadb/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnpostgresql-0.7.2/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnpostgresql-0.7.2) | [vshnpostgresql](charts/vshnpostgresql/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnpostgresql-0.8.0/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnpostgresql-0.8.0) | [vshnpostgresql](charts/vshnpostgresql/README.md) |
 
 ## Add / Update Charts
 

--- a/charts/vshnpostgresql/Chart.yaml
+++ b/charts/vshnpostgresql/Chart.yaml
@@ -20,8 +20,8 @@ apiVersion: v2
 name: vshnpostgresql
 description: A Helm chart for PostgreSQL clusters using the CloudNativePG operator
 type: application
-version: 0.7.2
-appVersion: 0.7.2
+version: 0.8.0
+appVersion: 0.8.0
 maintainers:
   - name: Schedar Team
     email: info@vshn.ch

--- a/charts/vshnpostgresql/README.md
+++ b/charts/vshnpostgresql/README.md
@@ -1,6 +1,6 @@
 # vshnpostgresql
 
-![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.2](https://img.shields.io/badge/AppVersion-0.7.2-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
 
 A Helm chart for PostgreSQL clusters using the CloudNativePG operator
 
@@ -96,6 +96,9 @@ refer to the [CloudNativePG Documentation](https://cloudnative-pg.io/documentati
 | backups.google.bucket | string | `""` |  |
 | backups.google.gkeEnvironment | bool | `false` |  |
 | backups.google.path | string | `"/"` |  |
+| backups.postUpgradeBackup.activeDeadlineSeconds | int | `3600` | Hard deadline in seconds for the job before it is killed |
+| backups.postUpgradeBackup.image | string | `"portainer/kubectl-shell:2.40.0"` | Image used by the post-upgrade backup job |
+| backups.postUpgradeBackup.ttlSecondsAfterFinished | int | `600` | Seconds after which a completed job is automatically deleted |
 | backups.provider | string | `"s3"` | One of `s3`, `azure` or `google` |
 | backups.retentionPolicy | string | `"30d"` | Retention policy for backups |
 | backups.s3.accessKey | string | `""` |  |

--- a/charts/vshnpostgresql/templates/backup-post-upgrade-rbac.yaml
+++ b/charts/vshnpostgresql/templates/backup-post-upgrade-rbac.yaml
@@ -1,0 +1,37 @@
+{{- if (eq (include "cluster.useBarmanCloudPlugin" .) "true") }}
+{{- $name := include "cluster.fullname" . -}}
+{{- $namespace := include "cluster.namespace" . }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}-post-upgrade
+  namespace: {{ $namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}-post-upgrade
+  namespace: {{ $namespace }}
+rules:
+- apiGroups: ["postgresql.cnpg.io"]
+  resources: ["clusters"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["postgresql.cnpg.io"]
+  resources: ["backups"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}-post-upgrade
+  namespace: {{ $namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name }}-post-upgrade
+subjects:
+- kind: ServiceAccount
+  name: {{ $name }}-post-upgrade
+  namespace: {{ $namespace }}
+{{- end }}

--- a/charts/vshnpostgresql/templates/scheduled-backups.yaml
+++ b/charts/vshnpostgresql/templates/scheduled-backups.yaml
@@ -22,4 +22,53 @@ spec:
   method: {{ .method }}
 {{- end }}
 {{ end -}}
+{{- if (eq (include "cluster.useBarmanCloudPlugin" .) "true") }}
+{{- $name := include "cluster.fullname" . -}}
+{{- $namespace := include "cluster.namespace" . -}}
+{{- $existingCluster := lookup "postgresql.cnpg.io/v1" "Cluster" $namespace $name -}}
+{{- if $existingCluster -}}
+{{- $currentVersion := $existingCluster.status.pgDataImageInfo.majorVersion | toString -}}
+{{- $targetVersion := .Values.version.postgresql | toString -}}
+{{- if ne $currentVersion $targetVersion }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $name }}-post-upgrade-v{{ $targetVersion }}
+  namespace: {{ $namespace }}
+spec:
+  ttlSecondsAfterFinished: {{ .Values.backups.postUpgradeBackup.ttlSecondsAfterFinished }}
+  activeDeadlineSeconds: {{ .Values.backups.postUpgradeBackup.activeDeadlineSeconds }}
+  template:
+    spec:
+      serviceAccountName: {{ $name }}-post-upgrade
+      restartPolicy: OnFailure
+      containers:
+      - name: post-upgrade-backup
+        image: {{ .Values.backups.postUpgradeBackup.image }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          echo "Waiting for major version upgrade to v{{ $targetVersion }} to complete..."
+          kubectl wait cluster/{{ $name }} -n {{ $namespace }} \
+            --for=jsonpath='{.status.pgDataImageInfo.majorVersion}'={{ $targetVersion }} \
+            --timeout=3550s
+          echo "Upgrade to v{{ $targetVersion }} complete, creating backup..."
+          kubectl create -f - <<'BACKUP'
+          apiVersion: postgresql.cnpg.io/v1
+          kind: Backup
+          metadata:
+            name: {{ $name }}-post-upgrade-v{{ $targetVersion }}
+            namespace: {{ $namespace }}
+          spec:
+            cluster:
+              name: {{ $name }}
+            method: plugin
+            pluginConfiguration:
+              name: barman-cloud.cloudnative-pg.io
+          BACKUP
+{{- end }}
+{{- end }}
+{{- end }}
 {{ end }}

--- a/charts/vshnpostgresql/values.yaml
+++ b/charts/vshnpostgresql/values.yaml
@@ -487,6 +487,14 @@ backups:
   # -- Retention policy for backups
   retentionPolicy: "30d"
 
+  postUpgradeBackup:
+    # -- Image used by the post-upgrade backup job
+    image: portainer/kubectl-shell:2.40.0
+    # -- Seconds after which a completed job is automatically deleted
+    ttlSecondsAfterFinished: 600
+    # -- Hard deadline in seconds for the job before it is killed
+    activeDeadlineSeconds: 3600
+
 replica:
   # --  Defines the name of this cluster. It is used to determine if this is a primary or a replica cluster, comparing it with primary. Leave empty by default.
   self: ""


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a post-major-version-upgrade backup job for CNPG PostgreSQL clusters. Base backups taken before a major version upgrade cannot be used after the upgrade, so a fresh backup is required.

Instead of creating the backup directly, a Kubernetes Job is used. It watches the cluster via `kubectl wait` until `status.pgDataImageInfo.majorVersion` matches the target version, then triggers the backup. This avoids a race condition where the backup could start before the upgrade completes.

The job is only rendered when Helm detects a version mismatch between the running cluster and the desired version in values.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]