### PR TITLE
Add external ObjectStore reference for CNPG restore operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ helm repo add appcat https://charts.appcat.ch
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragebucket-0.0.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragebucket-0.0.1) | [vshngaragebucket](charts/vshngaragebucket/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragecluster-0.0.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragecluster-0.0.1) | [vshngaragecluster](charts/vshngaragecluster/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnmariadb-0.0.12/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnmariadb-0.0.12) | [vshnmariadb](charts/vshnmariadb/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnpostgresql-0.7.2/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnpostgresql-0.7.2) | [vshnpostgresql](charts/vshnpostgresql/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnpostgresql-0.8.0/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnpostgresql-0.8.0) | [vshnpostgresql](charts/vshnpostgresql/README.md) |
 
 ## Add / Update Charts
 

--- a/charts/vshnpostgresql/Chart.yaml
+++ b/charts/vshnpostgresql/Chart.yaml
@@ -20,8 +20,8 @@ apiVersion: v2
 name: vshnpostgresql
 description: A Helm chart for PostgreSQL clusters using the CloudNativePG operator
 type: application
-version: 0.7.2
-appVersion: 0.7.2
+version: 0.8.0
+appVersion: 0.8.0
 maintainers:
   - name: Schedar Team
     email: info@vshn.ch

--- a/charts/vshnpostgresql/README.md
+++ b/charts/vshnpostgresql/README.md
@@ -1,6 +1,6 @@
 # vshnpostgresql
 
-![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.2](https://img.shields.io/badge/AppVersion-0.7.2-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
 
 A Helm chart for PostgreSQL clusters using the CloudNativePG operator
 
@@ -210,6 +210,7 @@ refer to the [CloudNativePG Documentation](https://cloudnative-pg.io/documentati
 | recovery.import.source.username | string | `""` |  |
 | recovery.import.type | string | `"microservice"` | One of `microservice` or `monolith.` See: https://cloudnative-pg.io/documentation/current/database_import/#how-it-works |
 | recovery.method | string | `"backup"` | Available recovery methods: * `backup` - Recovers a CNPG cluster from a CNPG backup (PITR supported) Needs to be on the same cluster in the same namespace. * `object_store` - Recovers a CNPG cluster from a barman object store (PITR supported). * `pg_basebackup` - Recovers a CNPG cluster viaa streaming replication protocol. Useful if you want to        migrate databases to CloudNativePG, even from outside Kubernetes. * `import` - Import one or more databases from an existing Postgres cluster. |
+| recovery.objectStoreName | string | `""` | Name of an externally managed ObjectStore to use for recovery. When set, the chart's own ObjectStore keeps backup credentials, and the external cluster references this ObjectStore instead. |
 | recovery.owner | string | `""` | Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key. |
 | recovery.pgBaseBackup.database | string | `"app"` | Name of the database used by the application. Default: `app`. |
 | recovery.pgBaseBackup.owner | string | `""` | Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key. |

--- a/charts/vshnpostgresql/templates/_external_clusters.tpl
+++ b/charts/vshnpostgresql/templates/_external_clusters.tpl
@@ -20,7 +20,7 @@ externalClusters:
     plugin:
       name: barman-cloud.cloudnative-pg.io
       parameters:
-        barmanObjectName: {{ include "cluster.fullname" $  }}-object-store
+        barmanObjectName: {{ .Values.recovery.objectStoreName | default (printf "%s-object-store" (include "cluster.fullname" .)) }}
         serverName: {{ .Values.recovery.clusterName |  default (include "cluster.fullname" .) }}
   {{- end }}
 {{- else if eq .Values.mode "replica" }}

--- a/charts/vshnpostgresql/templates/objectStore.yaml
+++ b/charts/vshnpostgresql/templates/objectStore.yaml
@@ -9,7 +9,7 @@ spec:
   retentionPolicy: {{ . }}
   {{- end }}
   configuration:
-  {{- if and (eq .Values.mode "recovery") (eq .Values.recovery.method "object_store") -}}
+  {{- if and (eq .Values.mode "recovery") (eq .Values.recovery.method "object_store") (empty .Values.recovery.objectStoreName) -}}
   {{- $d := dict "chartFullname" (include "cluster.fullname" .) "scope" .Values.recovery "secretPrefix" "recovery" -}}
   {{- include "cluster.barmanObjectStoreConfig" $d | indent 2 }}
   {{- else }}

--- a/charts/vshnpostgresql/templates/recovery-s3-creds.yaml
+++ b/charts/vshnpostgresql/templates/recovery-s3-creds.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.mode "recovery" ) (eq .Values.recovery.method "object_store") (eq .Values.recovery.provider "s3") (not .Values.recovery.s3.inheritFromIAMRole) .Values.recovery.secret.create }}
+{{- if and (eq .Values.mode "recovery" ) (eq .Values.recovery.method "object_store") (empty .Values.recovery.objectStoreName) (eq .Values.recovery.provider "s3") (not .Values.recovery.s3.inheritFromIAMRole) .Values.recovery.secret.create }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/vshnpostgresql/values.yaml
+++ b/charts/vshnpostgresql/values.yaml
@@ -49,6 +49,10 @@ recovery:
   ##
   # -- The original cluster name when used in backups. Also known as serverName.
   clusterName: ""
+  # -- Name of an externally managed ObjectStore to use for recovery.
+  # When set, the chart's own ObjectStore keeps backup credentials,
+  # and the external cluster references this ObjectStore instead.
+  objectStoreName: ""
   # -- Name of the database used by the application. Default: `app`.
   database: app
   # -- Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.


### PR DESCRIPTION
#### What this PR does / why we need it:

* Adds a `recovery.objectStoreName` value to reference an externally managed ObjectStore for restore operations
* When restoring from another instance's backup, this lets the external cluster point at the source instance's ObjectStore while the chart's own ObjectStore retains the new instance's backup credentials
* Bumps chart version to 0.8.0

#### Checklist
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata)