### PR TITLE
Don't use separate WAL storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ helm repo add appcat https://charts.appcat.ch
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragebucket-0.0.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragebucket-0.0.1) | [vshngaragebucket](charts/vshngaragebucket/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragecluster-0.0.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragecluster-0.0.1) | [vshngaragecluster](charts/vshngaragecluster/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnmariadb-0.0.12/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnmariadb-0.0.12) | [vshnmariadb](charts/vshnmariadb/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnpostgresql-0.8.0/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnpostgresql-0.8.0) | [vshnpostgresql](charts/vshnpostgresql/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnpostgresql-0.8.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnpostgresql-0.8.1) | [vshnpostgresql](charts/vshnpostgresql/README.md) |
 
 ## Add / Update Charts
 

--- a/charts/vshnpostgresql/Chart.yaml
+++ b/charts/vshnpostgresql/Chart.yaml
@@ -20,8 +20,8 @@ apiVersion: v2
 name: vshnpostgresql
 description: A Helm chart for PostgreSQL clusters using the CloudNativePG operator
 type: application
-version: 0.8.0
-appVersion: 0.8.0
+version: 0.8.1
+appVersion: 0.8.1
 maintainers:
   - name: Schedar Team
     email: info@vshn.ch

--- a/charts/vshnpostgresql/README.md
+++ b/charts/vshnpostgresql/README.md
@@ -1,6 +1,6 @@
 # vshnpostgresql
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.1](https://img.shields.io/badge/AppVersion-0.8.1-informational?style=flat-square)
 
 A Helm chart for PostgreSQL clusters using the CloudNativePG operator
 

--- a/charts/vshnpostgresql/templates/cluster.yaml
+++ b/charts/vshnpostgresql/templates/cluster.yaml
@@ -1,3 +1,10 @@
+{{- $name := include "cluster.fullname" . -}}
+{{- $namespace := include "cluster.namespace" . -}}
+{{- $existingCluster := lookup "postgresql.cnpg.io/v1" "Cluster" $namespace $name -}}
+{{- $walStorage := false -}}
+{{- if $existingCluster -}}
+  {{- $walStorage = not (empty $existingCluster.spec.walStorage ) -}}
+{{- end -}}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
@@ -27,7 +34,7 @@ spec:
     {{- if not (empty .Values.cluster.storage.storageClass) }}
     storageClass: {{ .Values.cluster.storage.storageClass }}
     {{- end }}
-  {{- if .Values.cluster.walStorage.enabled }}
+  {{- if $walStorage }}
   walStorage:
     size: {{ .Values.cluster.walStorage.size }}
     {{- if not (empty .Values.cluster.walStorage.storageClass) }}


### PR DESCRIPTION

<!--
Thank you for contributing to vshn/appcat-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

This change will make the instance not use a separate WAL volume.

Any existing instance will keep its applied configuration. So it will not break existing instances.

```
k -n vshn-postgresql-beck-pg1-45vjs get pvc
NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        VOLUMEATTRIBUTESCLASS   AGE
postgresql-1   Bound    pvc-a6750a0b-4a7e-468b-8909-44527c90d9b7   20Gi       RWO            csi-hostpath-fast   <unset>                 2m2s

13:54:42 in ~ via 🐳 orbstack at ☸️ kind-kindev
➜ k -n vshn-postgresql-beck-pg-wc2vj get pvc
NAME               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        VOLUMEATTRIBUTESCLASS   AGE
postgresql-1       Bound    pvc-80885362-52c8-4a25-a060-492bf831d59c   20Gi       RWO            csi-hostpath-fast   <unset>                 42m
postgresql-1-wal   Bound    pvc-7ae6821a-5fd7-435b-be24-609043f0d898   1Gi        RWO            csi-hostpath-fast   <unset>                 42m

13:55:54 in ~ via 🐳 orbstack at ☸️ kind-kindev
➜ k get releases
NAME                       NAMESPACE                        CHART               VERSION   SYNCED   READY   STATE      REVISION   DESCRIPTION        AGE
appcat-sla-reports-ndcv7   syn-appcat                       vshngaragebucket    0.0.1     True     True    deployed   1          Install complete   27h
beck-pg-wc2vj              vshn-postgresql-beck-pg-wc2vj    vshnpostgresql      0.0.0     True     True    deployed   4          Upgrade complete   42m
beck-pg-wc2vj-backup       syn-appcat                       vshngaragebucket    0.0.1     True     True    deployed   1          Install complete   42m
beck-pg1-45vjs             vshn-postgresql-beck-pg1-45vjs   vshnpostgresql      0.0.0     True     True    deployed   1          Install complete   3m53s
beck-pg1-45vjs-backup      syn-appcat                       vshngaragebucket    0.0.1     True     True    deployed   1          Install complete   3m54s
garage-76tjf               vshn-garage-garage-76tjf         vshngaragecluster   0.0.1     True     True    deployed   1          Install complete   27h
```

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
