### PR TITLE
Add support to enable an adminKey for the garage instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ helm repo add appcat https://charts.appcat.ch
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/forgejo-16.2.1-vshn.1/total)](https://github.com/vshn/appcat-charts/releases/tag/forgejo-16.2.1-vshn.1) | [forgejo](charts/forgejo/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/rcloneproxy-0.0.2/total)](https://github.com/vshn/appcat-charts/releases/tag/rcloneproxy-0.0.2) | [rcloneproxy](charts/rcloneproxy/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragebucket-0.0.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragebucket-0.0.1) | [vshngaragebucket](charts/vshngaragebucket/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragecluster-0.0.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragecluster-0.0.1) | [vshngaragecluster](charts/vshngaragecluster/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragecluster-0.0.2/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragecluster-0.0.2) | [vshngaragecluster](charts/vshngaragecluster/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnmariadb-0.0.12/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnmariadb-0.0.12) | [vshnmariadb](charts/vshnmariadb/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnpostgresql-0.8.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnpostgresql-0.8.1) | [vshnpostgresql](charts/vshnpostgresql/README.md) |
 

--- a/charts/vshngaragecluster/Chart.yaml
+++ b/charts/vshngaragecluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vshngaragecluster
 description: A Helm chart for deploying a garage cluster via garage operator
 type: application
-version: 0.0.1
+version: 0.0.2
 maintainers:
   - name: Schedar Team
     email: info@vshn.ch

--- a/charts/vshngaragecluster/README.md
+++ b/charts/vshngaragecluster/README.md
@@ -1,6 +1,6 @@
 # vshngaragecluster
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a garage cluster via garage operator
 
@@ -18,7 +18,7 @@ Common/Useful Link references from values.yaml
 [prometheus-operator]: https://github.com/coreos/prometheus-operator
 # vshngaragecluster
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a garage cluster via garage operator
 
@@ -32,6 +32,7 @@ A Helm chart for deploying a garage cluster via garage operator
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| adminKey | object | `{"enabled":false}` | Admin Key configuration |
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"enabled":true,"readOnlyRootFilesystem":false,"runAsNonRoot":true,"runAsUser":65532}` | Container security context configuration |
 | containerSecurityContext.allowPrivilegeEscalation | bool | `false` | Disallow privilege escalation |
 | containerSecurityContext.capabilities | object | `{"drop":["ALL"]}` | Linux capabilities to drop |

--- a/charts/vshngaragecluster/templates/garagekeys.yaml
+++ b/charts/vshngaragecluster/templates/garagekeys.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.adminKey.enabled -}}
+apiVersion: garage.rajsingh.info/v1alpha1
+kind: GarageKey
+metadata:
+  name: admin-key
+spec:
+  clusterRef:
+    name: garage
+  name: 'Admin Key'
+  secretTemplate:
+    name: 'admin-s3-credentials'
+  allBuckets:
+    read: true
+    write: true
+    owner: true
+{{- end }}

--- a/charts/vshngaragecluster/values.yaml
+++ b/charts/vshngaragecluster/values.yaml
@@ -15,6 +15,10 @@ service:
   # -- Service type
   type: ClusterIP
 
+# -- Admin Key configuration
+adminKey:
+  enabled: false
+
 # -- Resource requests and limits
 resources:
   requests:


### PR DESCRIPTION
<!--
Thank you for contributing to vshn/appcat-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

* This PR adds the option to create an adminKey for the garage cluster

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
