### PR TITLE
Update dependencies in garage charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ helm repo add appcat https://charts.appcat.ch
 | --- | --- |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/forgejo-16.2.1-vshn.1/total)](https://github.com/vshn/appcat-charts/releases/tag/forgejo-16.2.1-vshn.1) | [forgejo](charts/forgejo/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/rcloneproxy-0.0.2/total)](https://github.com/vshn/appcat-charts/releases/tag/rcloneproxy-0.0.2) | [rcloneproxy](charts/rcloneproxy/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragebucket-0.0.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragebucket-0.0.1) | [vshngaragebucket](charts/vshngaragebucket/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragecluster-0.0.2/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragecluster-0.0.2) | [vshngaragecluster](charts/vshngaragecluster/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragebucket-0.0.2/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragebucket-0.0.2) | [vshngaragebucket](charts/vshngaragebucket/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragecluster-0.0.3/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragecluster-0.0.3) | [vshngaragecluster](charts/vshngaragecluster/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnmariadb-0.0.12/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnmariadb-0.0.12) | [vshnmariadb](charts/vshnmariadb/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnpostgresql-0.8.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnpostgresql-0.8.1) | [vshnpostgresql](charts/vshnpostgresql/README.md) |
 

--- a/charts/vshngaragebucket/Chart.yaml
+++ b/charts/vshngaragebucket/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vshngaragebucket
 description: A Helm chart for deploying a garage cluster via garage operator
 type: application
-version: 0.0.1
+version: 0.0.2
 maintainers:
   - name: Schedar Team
     email: info@vshn.ch

--- a/charts/vshngaragebucket/README.md
+++ b/charts/vshngaragebucket/README.md
@@ -1,6 +1,6 @@
 # vshngaragebucket
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a garage cluster via garage operator
 
@@ -18,7 +18,7 @@ Common/Useful Link references from values.yaml
 [prometheus-operator]: https://github.com/coreos/prometheus-operator
 # vshngaragebucket
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a garage cluster via garage operator
 

--- a/charts/vshngaragebucket/templates/bucket.yaml
+++ b/charts/vshngaragebucket/templates/bucket.yaml
@@ -1,4 +1,4 @@
-apiVersion: garage.rajsingh.info/v1alpha1
+apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageBucket
 metadata:
   name: {{ .Values.bucketName }}

--- a/charts/vshngaragebucket/templates/credentials.yaml
+++ b/charts/vshngaragebucket/templates/credentials.yaml
@@ -1,4 +1,4 @@
-apiVersion: garage.rajsingh.info/v1alpha1
+apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageKey
 metadata:
   name: {{ .Values.bucketName }}
@@ -7,6 +7,7 @@ spec:
     name: {{.Values.clusterRef}}
     namespace: {{ include "instanceNamespace" . }}
   bucketPermissions:
-    - bucketRef: {{ .Values.bucketName }}
+    - bucketRef:
+        name: {{ .Values.bucketName }}
       read: true
       write: true

--- a/charts/vshngaragecluster/Chart.yaml
+++ b/charts/vshngaragecluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vshngaragecluster
 description: A Helm chart for deploying a garage cluster via garage operator
 type: application
-version: 0.0.2
+version: 0.0.3
 maintainers:
   - name: Schedar Team
     email: info@vshn.ch

--- a/charts/vshngaragecluster/README.md
+++ b/charts/vshngaragecluster/README.md
@@ -1,6 +1,6 @@
 # vshngaragecluster
 
-![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a garage cluster via garage operator
 
@@ -18,7 +18,7 @@ Common/Useful Link references from values.yaml
 [prometheus-operator]: https://github.com/coreos/prometheus-operator
 # vshngaragecluster
 
-![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a garage cluster via garage operator
 

--- a/charts/vshngaragecluster/templates/cluster.yaml
+++ b/charts/vshngaragecluster/templates/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: garage.rajsingh.info/v1alpha1
+apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageCluster
 metadata:
   name: garage
@@ -19,7 +19,7 @@ spec:
   replication:
     factor: {{.Values.replicaCount}}
   security:
-    allowWorldReadableSecrets: true
+    allowInsecureSecretPermissions: true
   storage:
     data:
       size: {{.Values.storageDataSpace}}
@@ -30,7 +30,6 @@ spec:
     service:
       type: ClusterIP
   admin:
-    enabled: true
     bindPort: 3903
     adminTokenSecretRef:
       name: garage-admin-token

--- a/charts/vshngaragecluster/templates/garagekeys.yaml
+++ b/charts/vshngaragecluster/templates/garagekeys.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.adminKey.enabled -}}
-apiVersion: garage.rajsingh.info/v1alpha1
+apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageKey
 metadata:
   name: admin-key


### PR DESCRIPTION
#### What this PR does / why we need it:

* Garage Operator helm chart moved its CRDs from `v1alpha1` to `v1beta1`, updating dependeincies

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
