### PR TITLE
Add GarageReferenceGrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ helm repo add appcat https://charts.appcat.ch
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/forgejo-16.2.1-vshn.1/total)](https://github.com/vshn/appcat-charts/releases/tag/forgejo-16.2.1-vshn.1) | [forgejo](charts/forgejo/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/rcloneproxy-0.0.2/total)](https://github.com/vshn/appcat-charts/releases/tag/rcloneproxy-0.0.2) | [rcloneproxy](charts/rcloneproxy/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragebucket-0.0.2/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragebucket-0.0.2) | [vshngaragebucket](charts/vshngaragebucket/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragecluster-0.0.3/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragecluster-0.0.3) | [vshngaragecluster](charts/vshngaragecluster/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragecluster-0.0.4/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragecluster-0.0.4) | [vshngaragecluster](charts/vshngaragecluster/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnmariadb-0.0.12/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnmariadb-0.0.12) | [vshnmariadb](charts/vshnmariadb/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnpostgresql-0.8.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnpostgresql-0.8.1) | [vshnpostgresql](charts/vshnpostgresql/README.md) |
 

--- a/charts/vshngaragecluster/Chart.yaml
+++ b/charts/vshngaragecluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vshngaragecluster
 description: A Helm chart for deploying a garage cluster via garage operator
 type: application
-version: 0.0.3
+version: 0.0.4
 maintainers:
   - name: Schedar Team
     email: info@vshn.ch

--- a/charts/vshngaragecluster/README.md
+++ b/charts/vshngaragecluster/README.md
@@ -1,6 +1,6 @@
 # vshngaragecluster
 
-![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a garage cluster via garage operator
 
@@ -18,7 +18,7 @@ Common/Useful Link references from values.yaml
 [prometheus-operator]: https://github.com/coreos/prometheus-operator
 # vshngaragecluster
 
-![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a garage cluster via garage operator
 
@@ -33,6 +33,7 @@ A Helm chart for deploying a garage cluster via garage operator
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | adminKey | object | `{"enabled":false}` | Admin Key configuration |
+| allowedNamespaces | list | `[]` | Namespaces permitted to reference this cluster's GarageKeys/Buckets via the garage-operator's GarageReferenceGrant. When empty no grant is emitted. The list is consumed by templates/referencegrant.yaml. |
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"enabled":true,"readOnlyRootFilesystem":false,"runAsNonRoot":true,"runAsUser":65532}` | Container security context configuration |
 | containerSecurityContext.allowPrivilegeEscalation | bool | `false` | Disallow privilege escalation |
 | containerSecurityContext.capabilities | object | `{"drop":["ALL"]}` | Linux capabilities to drop |

--- a/charts/vshngaragecluster/templates/referencegrant.yaml
+++ b/charts/vshngaragecluster/templates/referencegrant.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.allowedNamespaces }}
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: appcat-allowed
+spec:
+  from:
+  {{- range .Values.allowedNamespaces }}
+    - kind: GarageKey
+      namespace: {{ . | quote }}
+    - kind: GarageBucket
+      namespace: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/vshngaragecluster/values.yaml
+++ b/charts/vshngaragecluster/values.yaml
@@ -43,6 +43,11 @@ podSecurityContext:
   seLinuxOptions: {}
     # type: "spc_t"
 
+# -- Namespaces permitted to reference this cluster's GarageKeys/Buckets via
+# the garage-operator's GarageReferenceGrant. When empty no grant is emitted.
+# The list is consumed by templates/referencegrant.yaml.
+allowedNamespaces: []
+
 # -- Container security context configuration
 containerSecurityContext:
   # -- Enable container security context


### PR DESCRIPTION
#### What this PR does / why we need it:

This adds the ability to specify allowed namespaces in which the user is allowed to provision GarageKeys and GarageBuckets by using GarageReferenceGrants

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
