### PR TITLE
Add autoUpdateDataPlane field for operator update procedures

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ helm repo add appcat https://charts.appcat.ch
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/rcloneproxy-0.0.2/total)](https://github.com/vshn/appcat-charts/releases/tag/rcloneproxy-0.0.2) | [rcloneproxy](charts/rcloneproxy/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragebucket-0.0.2/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragebucket-0.0.2) | [vshngaragebucket](charts/vshngaragebucket/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragecluster-0.0.4/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragecluster-0.0.4) | [vshngaragecluster](charts/vshngaragecluster/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnmariadb-0.0.12/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnmariadb-0.0.12) | [vshnmariadb](charts/vshnmariadb/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnmariadb-0.0.13/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnmariadb-0.0.13) | [vshnmariadb](charts/vshnmariadb/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnpostgresql-0.8.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnpostgresql-0.8.1) | [vshnpostgresql](charts/vshnpostgresql/README.md) |
 
 ## Add / Update Charts

--- a/charts/vshnmariadb/Chart.yaml
+++ b/charts/vshnmariadb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.0.12
+appVersion: 0.0.13
 description: A Helm chart for MariaDB instances using the mariadb-operator
 name: vshnmariadb
-version: 0.0.12
+version: 0.0.13
 maintainers:
   - name: Schedar Team
     email: info@vshn.ch

--- a/charts/vshnmariadb/README.gotmpl.md
+++ b/charts/vshnmariadb/README.gotmpl.md
@@ -60,3 +60,8 @@ Only MariaDB official images are supported. |
 | ---                                   | ---                                       | ---
 | `tls.enabled`                         | Enabled is a flag to enable TLS           | true
 | `tls.required`                        | If tls connection should be enforced      | false
+
+### Update strategy
+| Parameter                             | Description                               | Default
+| ---                                   | ---                                       | ---
+| `updateStrategy.autoUpdateDataPlane`  | Whether the Galera data-plane version (agent and init containers) should be automatically updated based on the operator version   | false

--- a/charts/vshnmariadb/README.md
+++ b/charts/vshnmariadb/README.md
@@ -1,6 +1,6 @@
 # vshnmariadb
 
-![Version: 0.0.12](https://img.shields.io/badge/Version-0.0.12-informational?style=flat-square) ![AppVersion: 0.0.12](https://img.shields.io/badge/AppVersion-0.0.12-informational?style=flat-square)
+![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![AppVersion: 0.0.13](https://img.shields.io/badge/AppVersion-0.0.13-informational?style=flat-square)
 
 A Helm chart for MariaDB instances using the mariadb-operator
 
@@ -72,6 +72,11 @@ Only MariaDB official images are supported. |
 | ---                                   | ---                                       | ---
 | `tls.enabled`                         | Enabled is a flag to enable TLS           | true
 | `tls.required`                        | If tls connection should be enforced      | false
+
+### Update strategy
+| Parameter                             | Description                               | Default
+| ---                                   | ---                                       | ---
+| `updateStrategy.autoUpdateDataPlane`  | Whether the Galera data-plane version (agent and init containers) should be automatically updated based on the operator version   | false
 
 <!---
 Common/Useful Link references from values.yaml

--- a/charts/vshnmariadb/templates/mariadb.yaml
+++ b/charts/vshnmariadb/templates/mariadb.yaml
@@ -53,3 +53,5 @@ spec:
       name: {{ .Values.tls.serverCertSecretRef }}
     serverCASecretRef:
       name: {{ .Values.tls.serverCASecretRef }}
+  updateStrategy:
+    autoUpdateDataPlane: {{ .Values.updateStrategy.autoUpdateDataPlane }}

--- a/charts/vshnmariadb/values.yaml
+++ b/charts/vshnmariadb/values.yaml
@@ -33,3 +33,6 @@ tls:
   required: false
   serverCASecretRef: ""
   serverCertSecretRef: ""
+
+updateStrategy:
+  autoUpdateDataPlane: false


### PR DESCRIPTION
<!--
Thank you for contributing to vshn/appcat-charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

* The field is required to update the galera data-plane automatically to match the operators version. Without this flag we can't easily upgrade the operator


#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
