### PR TITLE
Change startup failureThreshold field

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ helm repo add appcat https://charts.appcat.ch
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/rcloneproxy-0.0.2/total)](https://github.com/vshn/appcat-charts/releases/tag/rcloneproxy-0.0.2) | [rcloneproxy](charts/rcloneproxy/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragebucket-0.0.2/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragebucket-0.0.2) | [vshngaragebucket](charts/vshngaragebucket/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshngaragecluster-0.0.4/total)](https://github.com/vshn/appcat-charts/releases/tag/vshngaragecluster-0.0.4) | [vshngaragecluster](charts/vshngaragecluster/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnmariadb-0.0.13/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnmariadb-0.0.13) | [vshnmariadb](charts/vshnmariadb/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnmariadb-0.0.14/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnmariadb-0.0.14) | [vshnmariadb](charts/vshnmariadb/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/vshn/appcat-charts/vshnpostgresql-0.8.1/total)](https://github.com/vshn/appcat-charts/releases/tag/vshnpostgresql-0.8.1) | [vshnpostgresql](charts/vshnpostgresql/README.md) |
 
 ## Add / Update Charts

--- a/charts/vshnmariadb/Chart.yaml
+++ b/charts/vshnmariadb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.0.13
+appVersion: 0.0.14
 description: A Helm chart for MariaDB instances using the mariadb-operator
 name: vshnmariadb
-version: 0.0.13
+version: 0.0.14
 maintainers:
   - name: Schedar Team
     email: info@vshn.ch

--- a/charts/vshnmariadb/README.gotmpl.md
+++ b/charts/vshnmariadb/README.gotmpl.md
@@ -23,7 +23,7 @@ Only MariaDB official images are supported. |
 | `resources`             | Resources describes the compute resource requirements.    |
 | `rootPasswordSecretKeyRef` | Reference to the secret containing the root password   |
 | `affinity`              | Definites the affinity for the pods                       |
-| `startupProbe`          | Startup probe configuration for MariaDB containers        | `{failureThreshold: 30}`
+| `startupProbe`          | Startup probe configuration for MariaDB containers        | `{failureThreshold: 120}`
 | `livenessProbe`         | Liveness probe configuration for MariaDB containers       |
 | `readinessProbe`        | Readiness probe configuration for MariaDB containers      |
 

--- a/charts/vshnmariadb/README.md
+++ b/charts/vshnmariadb/README.md
@@ -1,6 +1,6 @@
 # vshnmariadb
 
-![Version: 0.0.13](https://img.shields.io/badge/Version-0.0.13-informational?style=flat-square) ![AppVersion: 0.0.13](https://img.shields.io/badge/AppVersion-0.0.13-informational?style=flat-square)
+![Version: 0.0.14](https://img.shields.io/badge/Version-0.0.14-informational?style=flat-square) ![AppVersion: 0.0.14](https://img.shields.io/badge/AppVersion-0.0.14-informational?style=flat-square)
 
 A Helm chart for MariaDB instances using the mariadb-operator
 
@@ -35,7 +35,7 @@ Only MariaDB official images are supported. |
 | `resources`             | Resources describes the compute resource requirements.    |
 | `rootPasswordSecretKeyRef` | Reference to the secret containing the root password   |
 | `affinity`              | Definites the affinity for the pods                       |
-| `startupProbe`          | Startup probe configuration for MariaDB containers        | `{failureThreshold: 30}`
+| `startupProbe`          | Startup probe configuration for MariaDB containers        | `{failureThreshold: 120}`
 | `livenessProbe`         | Liveness probe configuration for MariaDB containers       |
 | `readinessProbe`        | Readiness probe configuration for MariaDB containers      |
 

--- a/charts/vshnmariadb/values.yaml
+++ b/charts/vshnmariadb/values.yaml
@@ -17,7 +17,7 @@ galera:
     "cert.log_conflicts": "yes"
 
 startupProbe:
-  failureThreshold: 30
+  failureThreshold: 120
 
 metrics:
   enabled: true


### PR DESCRIPTION
This PR increases the startup probe failure threshold from 30 probes to 120 probes

#### What this PR does / why we need it:

* Short summary

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `charts/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
